### PR TITLE
Move GPS communication to its own thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.8.0",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +373,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossbeam",
  "crossterm",
  "futures",
  "tokio",
@@ -422,6 +490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,7 +543,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Peter Simonsson <peter.simonsson@gmail.com>"]
 [dependencies]
 anyhow = "1.0.71"
 clap = { version = "4.3.0", features = ["derive"] }
+crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 crossterm = "0.26.1"
 futures = "0.3.28"
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }

--- a/src/gps.rs
+++ b/src/gps.rs
@@ -1,0 +1,75 @@
+use crossbeam::channel::{self, Receiver, Sender};
+use futures::StreamExt;
+use tokio_serial::SerialPortBuilderExt;
+use tokio_util::codec::{Decoder, LinesCodec};
+
+pub enum Message {
+    Curr(u64),
+    DevCurr(f64),
+    DevAccum(f64),
+    Deviation(f32),
+    DAC1(u32),
+    DAC2(u32),
+    Error,
+}
+
+pub struct Gps {
+    pub rx: Receiver<Message>,
+    _tx: Sender<Message>,
+}
+
+impl Gps {
+    pub fn new(device: String) -> Self {
+        let (tx, rx) = channel::unbounded();
+        let line_tx = tx.clone();
+
+        tokio::spawn(async move {
+            let mut port = tokio_serial::new(device, 115200)
+                .open_native_async()
+                .unwrap(); // TODO: Less unwrap!
+            port.set_exclusive(false).unwrap(); // TODO: Less unwrap!
+
+            let codec = LinesCodec::new();
+            let mut reader = codec.framed(port);
+
+            loop {
+                if let Some(line) = reader.next().await {
+                    let line = line.unwrap(); // TODO: Less unwrap!
+
+                    if line.starts_with("# Curr:") {
+                        let (_, data) = line.rsplit_once(' ').unwrap();
+                        line_tx.send(Message::Curr(data.parse().unwrap())).unwrap();
+                    } else if line.starts_with("# Deviation current:") {
+                        let (_, data) = line.rsplit_once(' ').unwrap();
+                        let data = data.strip_suffix("Hz").unwrap();
+                        line_tx
+                            .send(Message::DevCurr(data.parse().unwrap()))
+                            .unwrap();
+                    } else if line.starts_with("# Deviation accum:") {
+                        let (_, data) = line.rsplit_once(' ').unwrap();
+                        let data = data.strip_suffix("Hz").unwrap();
+                        line_tx
+                            .send(Message::DevAccum(data.parse().unwrap()))
+                            .unwrap();
+                    } else if line.starts_with("# New DAC1 value") {
+                        let (_, data) = line.rsplit_once(' ').unwrap();
+                        line_tx.send(Message::DAC1(data.parse().unwrap())).unwrap();
+                    } else if line.starts_with("# New DAC2 value") {
+                        let (_, data) = line.rsplit_once(' ').unwrap();
+                        line_tx.send(Message::DAC2(data.parse().unwrap())).unwrap();
+                    } else if line.starts_with("*") {
+                        let (_, data) = line.split_once(' ').unwrap();
+                        let data = data.strip_suffix(" ppb").unwrap();
+                        line_tx
+                            .send(Message::Deviation(data.parse().unwrap()))
+                            .unwrap();
+                    }
+                } else {
+                    line_tx.send(Message::Error).unwrap(); // TODO: Less unwrap!
+                }
+            }
+        });
+
+        Gps { rx, _tx: tx }
+    }
+}


### PR DESCRIPTION
Move GPS communication to its own thread to prepare for using tui crate to create a nicer UI. Pass messages with the data between the threads. Use a separate message for each data type.